### PR TITLE
Redis cluster - Python 3.x compatibility

### DIFF
--- a/kombu/tests/transport/test_redis_cluster.py
+++ b/kombu/tests/transport/test_redis_cluster.py
@@ -195,7 +195,7 @@ class Client(object):
             return conn
 
         def get_node_by_slot(self, key):
-            node = self.client.info().keys()[0]
+            node = list(self.client.info().keys())[0]
             host, port = node.split(':')
             return {
                 'host': host,

--- a/kombu/transport/redis_cluster.py
+++ b/kombu/transport/redis_cluster.py
@@ -139,7 +139,7 @@ def Mutex(client, name, expire):
                         pipe.watch(name)
                         pipe.multi(name)
                         pipe.delete(name)
-                        print pipe.execute()
+                        print(pipe.execute())
                         pipe.unwatch(name)
             except redis.WatchError:
                 pass
@@ -156,8 +156,8 @@ class QoS(virtual.QoS):
         delivery = message.delivery_info
         EX, RK = delivery['exchange'], delivery['routing_key']
         with self.pipe_or_acquire() as pipe:
-            print self.unacked_index_key, time(), delivery_tag
-            print self.unacked_key, delivery_tag, dumps([message._raw, EX, RK])
+            print(self.unacked_index_key, time(), delivery_tag)
+            print(self.unacked_key, delivery_tag, dumps([message._raw, EX, RK]))
 
             pipe.zadd(self.unacked_index_key, time(), delivery_tag) \
                 .hset(self.unacked_key, delivery_tag,


### PR DESCRIPTION
Thanks for your patch. I was stuck on redis-cluster-broker.

Hope this PR would help you to improve 3.x compatibility.